### PR TITLE
Expose dependency-extraction-webpack-plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ mix.block('resources/assets/scripts/blocks.js', 'scripts', {
   outputFormat: 'json',
 })
 ```
+
+Besides the plugin options there is a special flag for the common use case of turning off `@babel/runtime/regenerator` handling by `wp-polyfill`.
+
+```js
+mix.block('resources/assets/scripts/blocks.js', 'scripts', {
+  wpPolyfill: false,
+})
+```

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ import { RichText } from '@wordpress/block-editor'
 These packages are included as [webpack externals](https://webpack.js.org/configuration/externals/), so there is no reason to add them to your package file.
 
 You will also find a php manifest file accompanying each script in your distribution directory. This file declares an array of dependencies based on what you've used in your scripts. Require it and you're set.
+
+Additional [Dependency Extraction Webpack Plugin options](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin#options) maybe be provided as a third argument to `mix.block()`:
+
+```js
+mix.block('resources/assets/scripts/blocks.js', 'scripts', {
+  outputFormat: 'json',
+})
+```

--- a/index.js
+++ b/index.js
@@ -17,10 +17,22 @@ class Block extends JavaScript {
     ]
   }
 
+  register(entry, output, options = {}) {
+    this.userOptions = options;
+    super.register(entry, output);
+  }
+
   webpackPlugins() {
     const WordPressDependencyExtraction = require('@wordpress/dependency-extraction-webpack-plugin')
 
-    return new WordPressDependencyExtraction()
+    return new WordPressDependencyExtraction(this.pluginOptions())
+  }
+
+  pluginOptions() {
+    return Object.assign(
+      {},
+      this.userOptions,
+    );
   }
 
   babelConfig() {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ class Block extends JavaScript {
 
   pluginOptions() {
     return Object.assign(
-      {},
+      this.userOptions.wpPolyfill === false ? {
+        requestToExternal(request) {
+          if (request === '@babel/runtime/regenerator') {
+            return null;
+          }
+        },
+      } : {},
       this.userOptions,
     );
   }


### PR DESCRIPTION
I think turning off the `wp-polyfill` usage would be a common use case since consuming projects often want to handle polyfills themselves.

Turning it off by default might be confusing though since it's not a default if you read the `dependency-extraction-webpack-plugin` readme.

If you feel like keeping it simple i can remove that commit and just expose the configuration so users can fix it themselves until webpack 5 (i guess). 

See https://github.com/roots/sage/issues/2474