### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+## 1.1.0 May 24th, 2020
+
+### Added
+
+- Exposes the underlying `@wordpress/dependency-extraction-webpack-plugin` options.
+- Provides an additional option: `disableRegenerator` to WP polyfilling `babel/runtime/regenerator`.
+
 ## 1.0.0 January 8th, 2020
 
 - Publishing as an org scoped package on npm.
-- Update README
+- Update README.
 
 ## 0.2.0 July 10th, 2019
 
 ### Changed
 
-- Replaced custom webpack externals with mainline `@wordpress/dependency-extraction-webpack-plugin`
+- Replaced custom webpack externals with mainline `@wordpress/dependency-extraction-webpack-plugin`.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ mix.block('resources/assets/scripts/blocks.js', 'scripts', {
   outputFormat: 'json',
 })
 ```
+
+Besides the plugin options there is a special flag for the common use case of turning off `@babel/runtime/regenerator` handling by `wp-polyfill`.
+
+```js
+mix.block('resources/assets/scripts/blocks.js', 'scripts', {
+  wpPolyfill: false,
+})
+```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Besides the plugin options there is a special flag for the common use case of tu
 
 ```js
 mix.block('resources/assets/scripts/blocks.js', 'scripts', {
-  wpPolyfill: false,
+  disableRegenerator: true,
 })
 ```

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ import { RichText } from '@wordpress/block-editor'
 These packages are included as [webpack externals](https://webpack.js.org/configuration/externals/), so there is no reason to add them to your package file.
 
 You will also find a php manifest file accompanying each script in your distribution directory. This file declares an array of dependencies based on what you've used in your scripts. Require it and you're set.
+
+Additional [Dependency Extraction Webpack Plugin options](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin#options) maybe be provided as a third argument to `mix.block()`:
+
+```js
+mix.block('resources/assets/scripts/blocks.js', 'scripts', {
+  outputFormat: 'json',
+})
+```

--- a/index.js
+++ b/index.js
@@ -57,9 +57,7 @@ class Block extends JavaScript {
    * @return {array|object}
    */
   webpackPlugins() {
-    const WordPressDependencyExtraction = require('@wordpress/dependency-extraction-webpack-plugin')
-
-    return new WordPressDependencyExtraction({
+    return new DependencyExtractionPlugin({
       ...this.pluginOptions,
     })
   }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,22 @@
 const mix = require('laravel-mix')
-let JavaScript = require('laravel-mix/src/components/JavaScript')
+const JavaScript = require('laravel-mix/src/components/JavaScript')
+const DependencyExtractionPlugin = require('@wordpress/dependency-extraction-webpack-plugin')
 
+/**
+ * Laravel Mix WP Block
+ *
+ * @see https://laravel-mix.com/docs/5.0/extending-mix
+ * @see https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin
+ */
 class Block extends JavaScript {
   name() {
-    return 'blocks'
+    return ['blocks', 'block']
   }
-
+  /**
+   * All dependencies that should be installed by Mix.
+   *
+   * @return {array}
+   */
   dependencies() {
     this.requiresReload = `
       Dependencies have been installed. Please run again.
@@ -17,30 +28,47 @@ class Block extends JavaScript {
     ]
   }
 
+  /**
+   * Register the plugin component.
+   *
+   * @param  {string} entry
+   * @param  {string} output
+   * @param  {object} options
+   * @return {void}
+   */
   register(entry, output, options = {}) {
-    this.userOptions = options;
-    super.register(entry, output);
+    this.pluginOptions = (
+      options.disableRegenerator === true ? {
+        ...options,
+        requestToExternal: function(request) {
+          if (request === '@babel/runtime/regenerator') {
+            return null
+          }
+        },
+      } : options
+    )
+
+    super.register(entry, output)
   }
 
+  /**
+   * Plugins to be merged with the master webpack config.
+   *
+   * @return {array|object}
+   */
   webpackPlugins() {
     const WordPressDependencyExtraction = require('@wordpress/dependency-extraction-webpack-plugin')
 
-    return new WordPressDependencyExtraction(this.pluginOptions())
+    return new WordPressDependencyExtraction({
+      ...this.pluginOptions,
+    })
   }
 
-  pluginOptions() {
-    return Object.assign(
-      this.userOptions.wpPolyfill === false ? {
-        requestToExternal(request) {
-          if (request === '@babel/runtime/regenerator') {
-            return null;
-          }
-        },
-      } : {},
-      this.userOptions,
-    );
-  }
-
+  /**
+   * Babel config to be merged with the master Babel config.
+   *
+   * @return {object}
+   */
   babelConfig() {
     return {
       presets: ['@wordpress/babel-preset-default'],

--- a/index.js
+++ b/index.js
@@ -17,10 +17,22 @@ class Block extends JavaScript {
     ]
   }
 
+  register(entry, output, options = {}) {
+    this.userOptions = options;
+    super.register(entry, output);
+  }
+
   webpackPlugins() {
     const WordPressDependencyExtraction = require('@wordpress/dependency-extraction-webpack-plugin')
 
-    return new WordPressDependencyExtraction()
+    return new WordPressDependencyExtraction(this.pluginOptions())
+  }
+
+  pluginOptions() {
+    return Object.assign(
+      {},
+      this.userOptions,
+    );
   }
 
   babelConfig() {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ class Block extends JavaScript {
 
   pluginOptions() {
     return Object.assign(
-      {},
+      this.userOptions.wpPolyfill === false ? {
+        requestToExternal(request) {
+          if (request === '@babel/runtime/regenerator') {
+            return null;
+          }
+        },
+      } : {},
       this.userOptions,
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinypixelco/laravel-mix-wp-blocks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Laravel mix extension to transpile WordPress blocks.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Added

- Exposes the underlying `@wordpress/dependency-extraction-webpack-plugin` options.
- Provides an additional option: `disableRegenerator` to WP polyfilling `babel/runtime/regenerator`.
