### PR TITLE
fix: update for >=6.0.43

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ const DependencyExtractionPlugin = require('@wordpress/dependency-extraction-web
  * @see https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin
  */
 class Block extends JavaScript {
+  constructor() {
+    super();
+    this.context = Mix
+  }
+  
   name() {
     return ['blocks', 'block']
   }


### PR DESCRIPTION
Adds support for Laravel Mix 6.0.43+. Fixes #6 